### PR TITLE
Add python script, and update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository is cited from [xacro2urdf](https://github.com/doctorsrn/xacro2ur
 # Usage
 1. Prepare Your Folder:
 The folder you specify must contain:
-- A `urdf` folder with the necessary URDF files and xacro file.
-- A `meshes` folder with the associated mesh files.
-- A `launch` folder if you have launch files to run.
+    - A `urdf` folder with the necessary URDF files and xacro file.
+    - A `meshes` folder with the associated mesh files.
+    - A `launch` folder if you have launch files to run.
 
 2. Running the Script:
 You have two choices to transform your files:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 # fusion_xacro2urdf2unity
 This repository is cited from [xacro2urdf](https://github.com/doctorsrn/xacro2urdf). We write some scripts to help us quickly create URDF files for Unity from [fusion2urdf](https://github.com/syuntoku14/fusion2urdf).
 
-
-
 # Usage
+1. Prepare Your Folder:
+The folder you specify must contain:
+- A `urdf` folder with the necessary URDF files and xacro file.
+- A `meshes` folder with the associated mesh files.
+- A `launch` folder if you have launch files to run.
 
-Put the script into the same folder of `urdf` folder. And then run the script.
+2. Running the Script:
+You have two choices to transform your files:
+
+    - python version(Recommend)
+
+    ```python
+    python xacro2urdf.py /path/to/your/folder
+    ```
+
+    - sh script
+
+    Put the script into the same folder of `urdf` folder. And then run the script.
+
+
 

--- a/xacro2urdf.py
+++ b/xacro2urdf.py
@@ -1,0 +1,70 @@
+import os
+import shutil
+import urllib.request
+import subprocess
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert xacro file to URDF and prepare files for Unity."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=os.getcwd(),
+        help="Path to the folder containing the 'urdf' folder (default: current directory)."
+    )
+    args = parser.parse_args()
+
+    # 切換到指定的工作目錄
+    os.chdir(args.path)
+
+    # Check if the urdf folder exists
+    if not os.path.exists("urdf"):
+        print("Error, the 'urdf' folder doesn't exist. Please place this script into the same folder as the 'urdf' folder.")
+        input("Press Enter to exit...")
+        return
+
+    # Get the parent directory name (xxx_description)
+    robot_mesh = os.path.basename(os.getcwd())
+
+    # Set robot_name by removing '_description' from robot_mesh
+    robot_name = robot_mesh.replace("_description", "")
+
+    # Check if the urdf/<robot_name>.xacro file exists
+    xacro_file = os.path.join("urdf", f"{robot_name}.xacro")
+    if not os.path.exists(xacro_file):
+        print(f"Error, the '{xacro_file}' file doesn't exist.")
+        input("Press Enter to exit...")
+        return
+
+    # Download xacro.py only if it doesn't exist
+    xacro_script = "xacro.py"
+    if not os.path.exists(xacro_script):
+        url = "https://raw.githubusercontent.com/doctorsrn/xacro2urdf/master/xacro.py"
+        urllib.request.urlretrieve(url, xacro_script)
+
+    # Create directories and copy meshes
+    urdf_mesh_dir = os.path.join("urdf", robot_mesh, "meshes")
+    os.makedirs(urdf_mesh_dir, exist_ok=True)
+    if os.path.exists("meshes"):
+        shutil.copytree("meshes", urdf_mesh_dir, dirs_exist_ok=True)
+
+    # Run xacro.py to generate the URDF file
+    urdf_output = f"{robot_name}.urdf"
+    subprocess.run(["python", xacro_script, "-o", urdf_output, xacro_file])
+
+    # Overwrite output directory if it exists
+    output_dir = f"{robot_name}_to_unity"
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+
+    shutil.move(urdf_output, output_dir)
+    shutil.move(os.path.join("urdf", robot_mesh), output_dir)
+
+    print(f"Success. Your files are ready in the folder '{output_dir}'.")
+    input("Press Enter to exit...")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request updates the README file to better explain the transformation options. It clarifies that there are two methods to run the script:
1. Running via the Python command with a specified folder.
2. Placing the script in the same folder as the `urdf` folder and running it directly.

**Omitting .gazebo includes:**
Before passing the xacro file to `xacro.py`, any `<xacro:include>` directive that references a `.gazebo` file is replaced with a comment. This avoids XML parsing errors caused by non-XML-compliant gazebo files.

**Updating URDF Mesh File References:**
After generating the URDF file, any `<mesh>` element with a `filename` attribute starting with a `file://` URI is updated to use the `package://` schema. The package name is determined by the parent folder (i.e. `robot_mesh`), so that paths like:  
<mesh filename="file://D:/screamlab/tmp/jusrt_for_test_description/meshes/base_link.stl" scale="0.001 0.001 0.001"/>
trans to ->
<mesh filename="package://jusrt_for_test_description/meshes/base_link.stl" scale="0.001 0.001 0.001"/>
